### PR TITLE
history: consistently use simple present tense

### DIFF
--- a/About/history.html
+++ b/About/history.html
@@ -23,7 +23,7 @@ sub: '
 
 {% capture desc %}
 <p>
-  The notion of a microkernel first emerged in the 70&apos;s. At that
+  The notion of a microkernel first emerges in the 70&apos;s. At that
   time, operating systems largely ran in privileged mode, also known as kernel
   mode, to provide hardware abstraction mechanisms and services. First
   defined in Brinch Hansen&apos;s Nucleus, then in CMU&apos;s MACH kernel,
@@ -55,11 +55,11 @@ sub: '
       title="L4 kernel: microkernels can have high performance"
       description='
       <p>
-        In 1993, Jochen Liedtke demonstrated with his L4 kernel that microkernel
-        IPC could be fast, a factor 10-20 faster than contemporary
+        In 1993, Jochen Liedtke demonstrates with his L4 kernel that microkernel
+        IPC can be fast, a factor 10-20 faster than contemporary
         microkernels. This remarkable order-of-magnitude performance improvement
-        was the start of a journey that created a whole family of microkernels
-        and led to large-scale commercial deployment. Read more on L4
+        is the start of a journey that will create a whole family of microkernels
+        and lead to large-scale commercial deployment. Read more on L4
         microkernel design evolution during the decades that followed
         Liedtke&apos;s L4 in the
         paper <a href="https://www.google.fr/url?sa=t&source=web&rct=j&opi=89978449&url=https://trustworthy.systems/publications/nicta_full_text/8988.pdf&ved=2ahUKEwjR3Y76-YuLAxV2U6QEHflXM0MQFnoECBcQAQ&usg=AOvVaw0q8HSvt7xj8PyxXGQYvmHX">"L4
@@ -76,16 +76,16 @@ sub: '
       description='
 
       <p>
-        In 2004, after spending some years experimenting with microkernel
-        designs looking for performance and complexity reduction opportunities,
-        Gernot Heiser and Kevin Elphinstone partnered with Gerwin Klein in a
-        project that targeted highest assurance without compromising on performance:
-        producing a formally verified microkernel (of the L4 family) at no more
-        than 10% performance degradation. The L4.verified project started. Kevin
-        led the design of a new kernel of the L4 family which would be
-        verifiable, while Gerwin led the formal specification and verification
-        of it. seL4 was born. It not only met its performance goal, but ended up
-        being even faster than other L4 kernels.
+        In 2004, combining experience in microkernel design with expertise in
+        formal verification, Gernot Heiser and Kevin Elphinstone partner with
+        Gerwin Klein in a project that targets highest assurance without
+        compromising on performance: producing a formally verified microkernel
+        (of the L4 family) at no more than 10% performance degradation. The
+        L4.verified project starts. Kevin is leading the design of a new kernel
+        of the L4 family which would be verifiable, while Gerwin is leading the
+        formal specification and verification of it. seL4 is born. It not only
+        meets its performance goal, but ends up being even faster than other L4
+        kernels.
       </p>
 
         <img src="../images/tries-shutterstock/l4v.png"
@@ -97,18 +97,17 @@ sub: '
       title='0 sorries: first formally verified kernel'
       description='
       <p>
-	On July 29, 2009, the last "sorry" of the seL4 functional correctness
-	proof was eliminated. A "sorry" is an assumed theorem lacking a complete
-	proof. In the emerging field of proof engineering measuring
-	progress was uncharted territory &mdash; counting these "sorries" was one,
-	albeit imperfect, way to monitor progress: hundreds of theorems were
-	first stated and "sorried" so work on their proofs could be parallelised
-	and tracked. Being imperfect, the measure would go up from time to time,
-	for instance when new properties to be proven were discovered.
-  "0 sorries" meant there was nothing left to prove: the project was finished.
-  We now celebrate this day every year as the seL4 day, when the world&apos;s first
-  formally verified kernel with a machine-checked code-level proof came
-  into existence.
+	On July 29, 2009, the last "sorry" of the seL4 functional correctness proof is
+	eliminated. A "sorry" is an assumed theorem lacking a complete proof. In the
+	emerging field of proof engineering measuring progress was uncharted territory
+	&mdash; counting these "sorries" is one, albeit imperfect, way to monitor
+	progress: hundreds of theorems were first stated and "sorried" so work on
+	their proofs could be parallelised and tracked. Being imperfect, the measure
+	can go up during steady progress, for instance when new properties are
+	discovered that need to be proved. "0 sorries" means there is nothing left to
+	prove: the project is finished. We now celebrate this day every year to mark
+	the seL4 day, when the world&apos;s first formally verified kernel with a
+	machine-checked code-level proof came into existence.
       </p>
         <img src="../images/tries-shutterstock/0sorries.jpg"
              alt="0 sorries" class="mt-8 rounded-lg w-3/4 mx-auto shadow-lg">'
@@ -119,11 +118,11 @@ sub: '
 {% capture desc %}
 <p>
 	Functional correctness shows that the seL4 C code behaves exactly as its
-	specification mandates. Subsequent breakthroughs have demonstrated that
+	specification mandates. Subsequent breakthroughs demonstrate that
 	seL4 enforces the security properties of integrity, confidentiality and
 	authority confinement; that the binary code of seL4 has the same
 	behaviour as its C implementation; <a href="../Verification/">and
-	more</a>. Collectively, this "proof stack" provides unprecedented assurance
+	more</a>. Collectively, this proof stack provides unprecedented assurance
 	that applications running on seL4 can be strongly isolated, preventing
 	attacks from untrusted applications from propagating to critical ones.
 </p>
@@ -143,30 +142,31 @@ sub: '
       title="DARPA HACMS: seL4 protects unmanned helicopter against cyber-attacks"
       description='
       <p>
-        The impact of seL4&apos;s verification was immediately significant in the
-	<a href="../Research/">Research</a> area, with high-impact
+        In the research area, the impact of seL4&apos;s verification is immediately
+        apparent with high-impact
 	<a href="../Research/publications.html">publications</a> spanning the
-	disciplines of Systems, Formal Methods, and Software Engineering. Its lasting real-world
-	significance was marked by the
+	disciplines of Systems, Formal Methods, and Software Engineering. For
+  lasting real-word significance, it is the
 	DARPA-funded <a href="http://loonwerks.com/projects/hacms.html">HACMS
-	program</a>, where seL4 was demonstrated and embedded in a range of autonomous vehicles,
-	ranging from trucks, a land robot, and a quadcopter to Boeing&apos;s
+	program</a> that demonstrates and embeds seL4 in a range of autonomous vehicles,
+	ranging from trucks, a land robot, and a quadcopter, to Boeing&apos;s
 	Unmanned Little Bird helicopter. At the end-of-project
 	demonstration, the HACMS Red Team &mdash; a professional team of hackers &mdash;
-	was unsuccessful at compromising the security of the
-	helicopter, <span class="italic">in flight</span>: they were given full access
+	is unsuccessful at compromising the security of the
+	helicopter, <em>in flight</em>: they were given full access
 	to the uncritical camera feed, and were even given the keys to crash its
-	virtual machine, but seL4 prevented the cyber attack from compromising the
-	flight mission. This sent a resounding message, in DARPA and beyond, not only
+	virtual machine, but seL4 prevents the cyber attack from compromising the
+	flight mission. This sends a resounding message, in DARPA and beyond, not only
 	that formally verified software is usable in practice and provides
 	unprecedented assurance, but that it can be retrofitted into existing systems
-	to protect highly critical real-world systems. The ground-breaking research
-	was recognised with numerous <a href="../Research/awards.html">awards</a>.
+	to protect highly critical real-world systems. Today, the ground-breaking research
+	around seL4 is recognised by numerous <a href="../Research/awards.html">awards</a>.
       </p>
       <p>
-        seL4 was first ported to new architectures and platforms during HACMS.
+        The HACMS program also marks the beginning of porting seL4 to new
+        architectures and platforms.
         The original proof stack only held for Arm 32-bit hardware. During the
-        project the proof was ported to the Intel x64 architecture. This was the
+        project the proof was ported to the Intel x64 architecture. This is the
         start of a continuing widening of the scope of <a
         href="../todo.html">all supported architectures and platforms that seL4
         now supports.</a>
@@ -182,11 +182,11 @@ sub: '
       title="Freedom day: seL4 becomes Open Source"
       description='
       <p>
-        With its demonstrated research and real-world impact, seL4 attracted
-        significant interest. However, being proprietary hindered its adoption.
-        In July 2014, on the 29th to make the "seL4 day" a double-celebratory
-        day, the seL4 code and proofs became open source, paving the way to the
-        widespread <a href="use.html">use</a>
+        With its demonstrated research and real-world impact, seL4 attracts
+        significant interest. However, its proprietary license at the time
+        hinders its adoption. In July 2014, on the 29th to make the "seL4 day" a
+        double-celebratory day, the seL4 code and proofs becomes open source,
+        paving the way to the widespread <a href="use.html">use</a>
         it enjoys today.
       </p>
         <img src="../images/tries-shutterstock/sel4-github.png"
@@ -202,9 +202,9 @@ sub: '
       title="Launch of the seL4 Foundation"
       description='
       <p>
-	With increased adoption, this open source technology needed a neutral
+	Increased adoption of the open source technology is generating a need for a neutral
 	home with a long-term future. On April 7th, 2020,
-	the <a href="../Foundation/">seL4 Foundation</a> was created, with
+	the <a href="../Foundation/">seL4 Foundation</a> is created, with
 	Founding <a href="../Foundation/Membership/">Members</a> CSIRO&apos;s
 	Data61, <a href="https://cog.systems">Cog Systems</a>,
 	<a href="https://www.dornerworks.com">DornerWorks</a>, Ghost Locomotion,
@@ -221,16 +221,16 @@ sub: '
       title="seL4 becomes an Ecosystem"
       description='
       <p>
-        In 2021, the original core seL4 team became a network of
+        In 2021, the original core seL4 team becomes a network of
         organisations. The <a href="https://trustworthy.systems">Trustworthy
-        Systems group</a> continued seL4 research at <a
+        Systems group</a> continues seL4 research at <a
         href="https://www.unsw.edu.au">UNSW Sydney</a>. The seL4 proof leaders
-        founded <a href="https://proofcraft.systems">Proofcraft</a>, a company
+        create <a href="https://proofcraft.systems">Proofcraft</a>, a company
         that provides commercial support for formal verification and drives the
-        expansion of the seL4 proofs. A number of key seL4 experts joined <a
+        expansion of the seL4 proofs. A number of key seL4 experts join <a
         href="https://www.kry10.com">Kry10</a>, a company that is building an
         seL4-based platform for mission-critical connected devices. At the same
-        time, the ecosystem of seL4 users, adopters and developers kept growing,
+        time, the ecosystem of seL4 users, adopters and developers keeps growing,
         gathering annually at the <a href="../Foundation/Summit/">seL4
         summit</a> to share the latest developments of this technology that has
         now become a world-wide ecosystem.


### PR DESCRIPTION
Some parts needed a bit more rephrasing to make that happen, but largely meaning should be preserved.

See also discussion on 1d448f83c9500b2de4b76eff50ff31302dc24225

Might be easier to build this locally and read the entire page in context.